### PR TITLE
fix: convert-null-value-to-current-date-in-carbon

### DIFF
--- a/src/Writers/Database/DestinationTable.php
+++ b/src/Writers/Database/DestinationTable.php
@@ -120,6 +120,10 @@ class DestinationTable
     }
 
     private function transformDateCellValue($columnName, $value) {
+        if (is_null($value)) {
+            return null;
+        }
+
         if ($this->isDateColumn($columnName)) {
 
             if (is_numeric($value)) {


### PR DESCRIPTION
https://github.com/bfinlay/laravel-excel-seeder/blob/master/src/Writers/Database/DestinationTable.php#L136

```php
        if ($this->isDateColumn($columnName)) {

            if (is_numeric($value)) {
                if (in_array($columnName, $this->settings->unixTimestamps))
                        $date = Carbon::parse($value);
                else
                        $date = Carbon::parse(Date::excelToDateTimeObject($value));
            }
            else {
                if (isset($this->settings->dateFormats[$columnName])) {
                    $date = Carbon::createFromFormat($this->settings->dateFormats[$columnName], $value);
                }
                else {
                   // $value is null. $date is current date
                    $date = Carbon::parse($value);
                }
            }

            return $date->format('Y-m-d H:i:s.u');
        }
```